### PR TITLE
Add new TpmIdentifier project for retrieving a unique TPM identifier.

### DIFF
--- a/TpmIdentifier/.gitignore
+++ b/TpmIdentifier/.gitignore
@@ -1,0 +1,2 @@
+/x64
+/*.vcxproj.user

--- a/TpmIdentifier/Main.cpp
+++ b/TpmIdentifier/Main.cpp
@@ -1,0 +1,207 @@
+#include <windows.h>
+#include <bcrypt.h>
+#include <ncrypt.h>
+#include <cassert>
+#include <fstream>
+#include <vector>
+
+#pragma comment(lib, "Ncrypt.lib")
+#pragma comment(lib, "Crypt32.lib")
+
+#define NT_SUCCESS(Status)          (((NTSTATUS)(Status)) >= 0)
+#define STATUS_UNSUCCESSFUL         ((NTSTATUS)0xC0000001L)
+
+struct RsaPublicBlob {
+    std::vector<BYTE> buffer; // EKpub buffer
+
+    BCRYPT_RSAKEY_BLOB* Header() const {
+        auto* header = (BCRYPT_RSAKEY_BLOB*)buffer.data();
+        assert(header->Magic == BCRYPT_RSAPUBLIC_MAGIC); // 0x31415352  // RSA1
+        return header;
+    }
+
+    /** Return RSA exponent in big-endian format */
+    std::vector<BYTE> Exponent() const {
+        BCRYPT_RSAKEY_BLOB* header = Header();
+
+        const BYTE* ptr = buffer.data() + sizeof(BCRYPT_RSAKEY_BLOB);
+        std::vector<BYTE> exponent(header->cbPublicExp, 0); // big-endian
+        memcpy(exponent.data(), ptr, header->cbPublicExp);
+        return exponent;
+    }
+
+    /** Return RSA modulus in big-endian format */
+    std::vector<BYTE> Modulus() const {
+        BCRYPT_RSAKEY_BLOB* header = Header();
+
+        const BYTE* ptr = buffer.data() + sizeof(BCRYPT_RSAKEY_BLOB) + header->cbPublicExp;
+        std::vector<BYTE> modulus(header->cbModulus, 0); // big-endian
+        memcpy(modulus.data(), ptr, header->cbModulus);
+        ptr += header->cbModulus;
+        assert(ptr == buffer.data() + buffer.size()); // reached end of EKpub buffer
+        return modulus;
+    }
+
+    /** Compute SHA-256 hash of the public key. Matches the following implementations:
+        * PowerShell: (Get-TpmEndorsementKeyInfo -Hash "Sha256").PublicKeyHash
+        * .Net: SHA256.HashData(RSA.Create(parameters).ExportRSAPublicKey()) with parameters.Exponent and parameters.Modulus set. */
+    std::vector<BYTE> PublicKeyHash() const {
+#if 0
+        // TODO: Hash doesn't match (Get-TpmEndorsementKeyInfo -Hash "Sha256").PublicKeyHash
+        std::vector<BYTE> hash(32, 0);
+        DWORD hash_len = (DWORD)hash.size();
+
+        //BOOL ok = CryptHashCertificate(NULL, CALG_SHA_256, 0, buffer.data(), (DWORD)buffer.size(), hash.data(), &hash_len);
+        //assert(ok);
+
+        CERT_PUBLIC_KEY_INFO info{};
+        info.Algorithm.pszObjId = (char*)szOID_RSA;
+        info.Algorithm.Parameters = { 0, nullptr };
+        info.PublicKey = { (DWORD)buffer.size(), (BYTE*)buffer.data(), 0 };
+
+        BOOL ok = CryptHashPublicKeyInfo(NULL, CALG_SHA_256, 0, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, &info, hash.data(), &hash_len);
+        assert(ok);
+        assert(hash_len == hash.size());
+        return hash;
+#else
+        // ASN DER export of Modulus & Exponent parameters (see https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.Pkcs1.cs)
+        std::vector<BYTE> data; // data to be hashed
+        
+        data.push_back(0x30); // sequence
+        data.push_back(0x82); // 2 bytes length (MSB set)
+        data.push_back(0x01); // 266bytes
+        data.push_back(0x0A); // 
+
+        data.push_back(0x02); // integer
+        data.push_back(0x82); // 2 bytes length (MSB set)
+        data.push_back(0x01); // 257bytes
+        data.push_back(0x01); // 
+        data.push_back(0x00); // leading byte
+        auto modulus = Modulus();
+        data.insert(data.end(), modulus.begin(), modulus.end());
+
+        data.push_back(0x02); // integer
+        data.push_back(0x03); // 3 bytes
+        auto exponent = Exponent();
+        data.insert(data.end(), exponent.begin(), exponent.end());
+
+        return Sha256(data);
+#endif
+    }
+
+    void PrintHeader() const {
+        BCRYPT_RSAKEY_BLOB* header = Header();
+
+        printf("Algorithm: ");
+        for (size_t i = 0; i < sizeof(header->Magic); i++) {
+            BYTE elm = ((BYTE*)&header->Magic)[i];
+            printf("%c", elm);
+        }
+        printf("\n");
+        printf("Bit length: %u\n", header->BitLength);
+        printf("Exponent length: %u\n", header->cbPublicExp);
+        printf("Modulus length: %u\n", header->cbModulus);
+        printf("Prime1 length: %u\n", header->cbPrime1);
+        printf("Prime2 length: %u\n", header->cbPrime2);
+    }
+
+    void SaveToFile(const char* filename) const {
+        std::ofstream file(filename, std::ofstream::out | std::ofstream::binary);
+        file.write((char*)&buffer, buffer.size());
+    }
+
+private:
+    /** Compute SHA-256 hash of the input data. */
+    static std::vector<BYTE> Sha256(const std::vector<BYTE>& data) {
+        std::vector<BYTE> hash(32, 0);
+
+        //open an algorithm handle
+        NTSTATUS status = STATUS_UNSUCCESSFUL;
+        BCRYPT_ALG_HANDLE hAlg = NULL;
+        if (!NT_SUCCESS(status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, NULL, 0))) {
+            wprintf(L"**** Error 0x%x returned by BCryptOpenAlgorithmProvider\n", status);
+            abort();
+        }
+
+        //calculate the size of the buffer to hold the hash object
+        DWORD cbData = 0, cbHashObject = 0;
+        if (!NT_SUCCESS(status = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, (PBYTE)&cbHashObject, sizeof(DWORD), &cbData, 0))) {
+            wprintf(L"**** Error 0x%x returned by BCryptGetProperty\n", status);
+            abort();
+        }
+
+        //allocate the hash object on the heap
+        BYTE* pbHashObject = (PBYTE)HeapAlloc(GetProcessHeap(), 0, cbHashObject);
+        if (NULL == pbHashObject) {
+            wprintf(L"**** memory allocation failed\n");
+            abort();
+        }
+
+        {
+            // check the length of the hash
+            DWORD cbHash = 0;
+            if (!NT_SUCCESS(status = BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH, (PBYTE)&cbHash, sizeof(DWORD), &cbData, 0))) {
+                wprintf(L"**** Error 0x%x returned by BCryptGetProperty\n", status);
+                abort();
+            }
+            assert(hash.size() == cbHash);
+        }
+
+        // create a hash
+        BCRYPT_HASH_HANDLE hHash = NULL;
+        if (!NT_SUCCESS(status = BCryptCreateHash(hAlg, &hHash, pbHashObject, cbHashObject, NULL, 0, 0))) {
+            wprintf(L"**** Error 0x%x returned by BCryptCreateHash\n", status);
+            abort();
+        }
+
+        // hash data
+        if (!NT_SUCCESS(status = BCryptHashData(hHash, (UCHAR*)data.data(), (ULONG)data.size(), 0))) {
+            wprintf(L"**** Error 0x%x returned by BCryptHashData\n", status);
+            abort();
+        }
+
+        // close the hash
+        if (!NT_SUCCESS(status = BCryptFinishHash(hHash, hash.data(), (ULONG)hash.size(), 0))) {
+            wprintf(L"**** Error 0x%x returned by BCryptFinishHash\n", status);
+            abort();
+        }
+
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        BCryptDestroyHash(hHash);
+        HeapFree(GetProcessHeap(), 0, pbHashObject);
+        return hash;
+    }
+};
+
+
+int main() {
+    NCRYPT_PROV_HANDLE hProv = NULL;
+    HRESULT hr = HRESULT_FROM_WIN32(NCryptOpenStorageProvider(&hProv, MS_PLATFORM_CRYPTO_PROVIDER, 0));
+    if (FAILED(hr)) {
+        abort();
+    }
+
+    // retrieve EK public key as RSA public key BLOB
+    // DOC: https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob
+    RsaPublicBlob rsaBlob;
+    rsaBlob.buffer.resize(1024, 0);
+    DWORD ekPub_len = 0;
+    hr = HRESULT_FROM_WIN32(NCryptGetProperty(hProv, NCRYPT_PCP_RSA_EKPUB_PROPERTY, rsaBlob.buffer.data(), (DWORD)rsaBlob.buffer.size(), &ekPub_len, 0)); // "PCP_RSA_EKPUB"
+    if (FAILED(hr)) {
+        abort();
+    }
+    rsaBlob.buffer.resize(ekPub_len);
+#if 0
+    rsaBlob.PrintHeader();
+    rsaBlob.SaveToFile("TPM_EKpub.bin");
+#endif
+
+    std::vector<BYTE> hash = rsaBlob.PublicKeyHash();
+    printf("TPM EKpub public key hash: ");
+    for (BYTE elm : hash)
+        printf("%02x", elm);
+    printf("\n");
+
+    NCryptFreeObject(hProv);
+    hProv = NULL;
+}

--- a/TpmIdentifier/TpmIdentifier.vcxproj
+++ b/TpmIdentifier/TpmIdentifier.vcxproj
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{96878dc7-0e9a-420a-a2bf-76ac714cc5c2}</ProjectGuid>
+    <RootNamespace>TpmIdentifier</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/TpmIdentifier/TpmIdentifier.vcxproj.filters
+++ b/TpmIdentifier/TpmIdentifier.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+</Project>

--- a/WebClient.sln
+++ b/WebClient.sln
@@ -13,6 +13,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WebClientUwp", "WebClientUw
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ProxyConfig", "ProxyConfig\ProxyConfig.vcxproj", "{2F1949F5-A4E7-420A-A522-B4C896038C88}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TpmIdentifier", "TpmIdentifier\TpmIdentifier.vcxproj", "{96878DC7-0E9A-420A-A2BF-76AC714CC5C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -37,6 +39,10 @@ Global
 		{2F1949F5-A4E7-420A-A522-B4C896038C88}.Debug|x64.Build.0 = Debug|x64
 		{2F1949F5-A4E7-420A-A522-B4C896038C88}.Release|x64.ActiveCfg = Release|x64
 		{2F1949F5-A4E7-420A-A522-B4C896038C88}.Release|x64.Build.0 = Release|x64
+		{96878DC7-0E9A-420A-A2BF-76AC714CC5C2}.Debug|x64.ActiveCfg = Debug|x64
+		{96878DC7-0E9A-420A-A2BF-76AC714CC5C2}.Debug|x64.Build.0 = Debug|x64
+		{96878DC7-0E9A-420A-A2BF-76AC714CC5C2}.Release|x64.ActiveCfg = Release|x64
+		{96878DC7-0E9A-420A-A2BF-76AC714CC5C2}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #25. The implementation is a bit rough, but it is verified to match the output of the PowerShell `(Get-TpmEndorsementKeyInfo -Hash "Sha256").PublicKeyHash` command.

The tool does NOT require administrative privileges.